### PR TITLE
Update renovate.json to not ignore PHP version when running Composer tasks

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -26,7 +26,7 @@
   ],
   "prHourlyLimit": 0,
   "rangeStrategy": "update-lockfile",
-  "composerIgnorePlatformReqs": ["ext-*", "lib-*", "php"],
+  "composerIgnorePlatformReqs": ["ext-*", "lib-*"],
   "automerge": true,
   "automergeType": "pr",
   "automergeStrategy": "squash",


### PR DESCRIPTION
Most other repositories that are >= 8.0 are ignoring PHP version as Renovate runs its Docker containers with PHP 7.4, this isn't the case here.