### PR TITLE
Modernize Rector config, fix PHPStan config

### DIFF
--- a/rector.php
+++ b/rector.php
@@ -2,20 +2,15 @@
 
 declare(strict_types=1);
 
-use Rector\Core\Configuration\Option;
+use Rector\Config\RectorConfig;
 use Rector\Core\ValueObject\PhpVersion;
 use Rector\Set\ValueObject\LevelSetList;
 use Rector\Set\ValueObject\SetList;
-use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 
-return static function (ContainerConfigurator $containerConfigurator): void {
-    $parameters = $containerConfigurator->parameters();
-    $parameters->set(Option::PATHS, [__DIR__.'/src', __DIR__.'/tests']);
-    $parameters->set(Option::PHP_VERSION_FEATURES, PhpVersion::PHP_74);
-    $parameters->set(Option::PARALLEL, true);
-    $parameters->set(Option::PHPSTAN_FOR_RECTOR_PATH, __DIR__.'/tools/php-cs-fixer/phpstan.neon');
-
-    $containerConfigurator->import(SetList::CODE_QUALITY);
-    $containerConfigurator->import(SetList::TYPE_DECLARATION_STRICT);
-    $containerConfigurator->import(LevelSetList::UP_TO_PHP_74);
+return static function (RectorConfig $rector): void {
+    $rector->parallel();
+    $rector->paths([__DIR__.'/src', __DIR__.'/tests']);
+    $rector->phpVersion(PhpVersion::PHP_74);
+    $rector->phpstanConfig(__DIR__.'/tools/phpstan/phpstan-rector.neon');
+    $rector->sets([SetList::CODE_QUALITY, SetList::TYPE_DECLARATION_STRICT, LevelSetList::UP_TO_PHP_74]);
 };

--- a/tools/phpstan/phpstan-rector.neon
+++ b/tools/phpstan/phpstan-rector.neon
@@ -1,0 +1,3 @@
+includes:
+    - ../../vendor/phpstan/phpstan-phpunit/extension.neon
+    - ../../vendor/phpstan/phpstan-beberlei-assert/extension.neon

--- a/tools/phpstan/phpstan.neon
+++ b/tools/phpstan/phpstan.neon
@@ -1,8 +1,8 @@
 includes:
-    - %rootDir%/../../../vendor/phpstan/phpstan-phpunit/extension.neon
-    - %rootDir%/../../../vendor/phpstan/phpstan-beberlei-assert/extension.neon
-    - %rootDir%/../../../vendor/phpstan/phpstan-strict-rules/rules.neon
-    - %rootDir%/../../../vendor/phpstan/phpstan-deprecation-rules/rules.neon
+    - ../../vendor/phpstan/phpstan-phpunit/extension.neon
+    - ../../vendor/phpstan/phpstan-beberlei-assert/extension.neon
+    - ../../vendor/phpstan/phpstan-strict-rules/rules.neon
+    - ../../vendor/phpstan/phpstan-deprecation-rules/rules.neon
 
 parameters:
     level: 8


### PR DESCRIPTION
- Use `RectorConfig` as it's now required in latest version
- Fix include pathing for PHPStan